### PR TITLE
Réorganiser l'affichage des postes et moderniser les cadres

### DIFF
--- a/composeur-rugby.html
+++ b/composeur-rugby.html
@@ -302,13 +302,13 @@
     .composition-field {
       position: relative;
       border-radius: 24px;
-      padding: 24px;
+      padding: 28px;
       background: linear-gradient(180deg, #15733b 0%, #0f9d58 60%, #0a7b34 100%);
       box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.1);
       display: grid;
-      grid-template-columns: repeat(12, minmax(0, 1fr));
-      grid-auto-rows: minmax(78px, 1fr);
-      gap: 12px;
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+      grid-auto-rows: minmax(92px, 1fr);
+      gap: 18px;
       color: #fff;
     }
 
@@ -332,26 +332,44 @@
 
     .position-slot {
       position: relative;
-      border-radius: 16px;
-      border: 1px solid rgba(255, 255, 255, 0.35);
-      background: rgba(12, 75, 38, 0.35);
-      padding: 12px 12px 16px;
+      border-radius: 18px;
+      border: 1.5px solid transparent;
+      padding: 14px 14px 20px;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: flex-start;
       text-align: center;
-      gap: 6px;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      gap: 8px;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      background:
+        linear-gradient(162deg, rgba(13, 95, 52, 0.82), rgba(8, 67, 34, 0.6)) padding-box,
+        linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(0, 168, 232, 0.45), rgba(10, 54, 146, 0.65)) border-box;
+      box-shadow: 0 22px 38px rgba(0, 0, 0, 0.32);
+      backdrop-filter: blur(3px);
+      isolation: isolate;
+    }
+
+    .position-slot::after {
+      content: "";
+      position: absolute;
+      inset: 16px 20px -26px;
+      background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.35), transparent 65%);
+      border-radius: 999px;
+      z-index: -1;
+      opacity: 0.65;
+      pointer-events: none;
     }
 
     .position-slot:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.16);
+      transform: translateY(-3px);
+      box-shadow: 0 28px 48px rgba(0, 0, 0, 0.42);
     }
 
     .position-slot.filled {
-      background: rgba(12, 75, 38, 0.55);
+      background:
+        linear-gradient(165deg, rgba(15, 118, 64, 0.9), rgba(10, 78, 41, 0.68)) padding-box,
+        linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(0, 168, 232, 0.55), rgba(10, 54, 146, 0.75)) border-box;
     }
 
     .position-number {
@@ -465,7 +483,7 @@
 
     @media (max-width: 1024px) {
       .composition-field {
-        grid-auto-rows: minmax(72px, 1fr);
+        grid-auto-rows: minmax(82px, 1fr);
       }
     }
 
@@ -481,7 +499,10 @@
       }
 
       .composition-field {
-        grid-auto-rows: minmax(66px, 1fr);
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+        grid-auto-rows: minmax(72px, 1fr);
+        gap: 14px;
+        padding: 22px;
       }
     }
 
@@ -593,21 +614,21 @@
     })();
 
     const POSITION_PRESET = [
-      { id: "pos-1", number: "1", label: "Pilier gauche", row: 1, colStart: 2, colSpan: 3 },
-      { id: "pos-2", number: "2", label: "Talonneur", row: 1, colStart: 5, colSpan: 3 },
-      { id: "pos-3", number: "3", label: "Pilier droit", row: 1, colStart: 8, colSpan: 3 },
-      { id: "pos-4", number: "4", label: "Deuxième ligne", row: 2, colStart: 4, colSpan: 3 },
-      { id: "pos-5", number: "5", label: "Deuxième ligne", row: 2, colStart: 7, colSpan: 3 },
-      { id: "pos-6", number: "6", label: "Troisième ligne aile", row: 3, colStart: 1, colSpan: 3 },
-      { id: "pos-7", number: "7", label: "Troisième ligne aile", row: 3, colStart: 9, colSpan: 3 },
-      { id: "pos-8", number: "8", label: "Troisième ligne centre", row: 3, colStart: 5, colSpan: 3 },
-      { id: "pos-9", number: "9", label: "Demi de mêlée", row: 4, colStart: 4, colSpan: 3 },
-      { id: "pos-10", number: "10", label: "Demi d'ouverture", row: 4, colStart: 7, colSpan: 3 },
-      { id: "pos-11", number: "11", label: "Ailier gauche", row: 5, colStart: 1, colSpan: 3 },
-      { id: "pos-12", number: "12", label: "Centre intérieur", row: 5, colStart: 4, colSpan: 3 },
-      { id: "pos-13", number: "13", label: "Centre extérieur", row: 5, colStart: 7, colSpan: 3 },
-      { id: "pos-14", number: "14", label: "Ailier droit", row: 5, colStart: 10, colSpan: 3 },
-      { id: "pos-15", number: "15", label: "Arrière", row: 6, colStart: 5, colSpan: 3 }
+      { id: "pos-1", number: "1", label: "Pilier gauche", row: 1, colStart: 1, colSpan: 2 },
+      { id: "pos-2", number: "2", label: "Talonneur", row: 1, colStart: 3, colSpan: 2 },
+      { id: "pos-3", number: "3", label: "Pilier droit", row: 1, colStart: 5, colSpan: 2 },
+      { id: "pos-4", number: "4", label: "Deuxième ligne", row: 2, colStart: 2, colSpan: 2 },
+      { id: "pos-5", number: "5", label: "Deuxième ligne", row: 2, colStart: 4, colSpan: 2 },
+      { id: "pos-6", number: "6", label: "Troisième ligne aile", row: 3, colStart: 1, colSpan: 2 },
+      { id: "pos-8", number: "8", label: "Troisième ligne centre", row: 3, colStart: 3, colSpan: 2 },
+      { id: "pos-7", number: "7", label: "Troisième ligne aile", row: 3, colStart: 5, colSpan: 2 },
+      { id: "pos-9", number: "9", label: "Demi de mêlée", row: 4, colStart: 2, colSpan: 2 },
+      { id: "pos-10", number: "10", label: "Demi d'ouverture", row: 4, colStart: 4, colSpan: 2 },
+      { id: "pos-11", number: "11", label: "Ailier gauche", row: 5, colStart: 1, colSpan: 1 },
+      { id: "pos-12", number: "12", label: "Centre intérieur", row: 5, colStart: 2, colSpan: 2 },
+      { id: "pos-13", number: "13", label: "Centre extérieur", row: 5, colStart: 4, colSpan: 2 },
+      { id: "pos-14", number: "14", label: "Ailier droit", row: 5, colStart: 6, colSpan: 1 },
+      { id: "pos-15", number: "15", label: "Arrière", row: 6, colStart: 3, colSpan: 2 }
     ];
 
     const defaultState = () => ({


### PR DESCRIPTION
## Summary
- Ajuste la grille du terrain pour resserrer la disposition des postes et réaligner les lignes 1-2-3, 6-8-7 et 15.
- Modernise le cadre des joueurs avec un contour dégradé, une ombre douce et un fond partiellement transparent.
- Adapte légèrement les espacements et la responsivité de la grille pour conserver une mise en page esthétique.

## Testing
- Not run (non-applicable).


------
https://chatgpt.com/codex/tasks/task_e_68cacd8e42508333a6654a8c41522649