### PR TITLE
Harmonise les thèmes couleur des blocs d'équipes

### DIFF
--- a/composeur-rugby.html
+++ b/composeur-rugby.html
@@ -310,6 +310,55 @@
       font-size: 1.6rem;
     }
 
+    .team-card {
+      --field-bg: linear-gradient(180deg, #dff5e6 0%, #c9ebd6 100%);
+      --field-foreground: #134f2d;
+      --field-outline: rgba(31, 122, 74, 0.14);
+      --slot-bg: #1f7a4a;
+      --slot-bg-filled: #1a6b41;
+      --slot-shadow: 0 14px 28px rgba(31, 122, 74, 0.28);
+      --slot-shadow-hover: 0 20px 36px rgba(31, 122, 74, 0.36);
+      --slot-text: #f5fffb;
+      --slot-number-text: #1a5c3b;
+      --role-slot-bg: rgba(255, 255, 255, 0.16);
+      --role-slot-starter-bg: rgba(255, 255, 255, 0.22);
+      --role-slot-starter-shadow: 0 6px 16px rgba(0, 0, 0, 0.16);
+      --role-slot-sub-bg: rgba(7, 51, 28, 0.35);
+      --placeholder-bg: rgba(255, 255, 255, 0.18);
+    }
+
+    .team-card[data-team-id="blue"] {
+      --field-bg: linear-gradient(180deg, #deedff 0%, #cfe4ff 100%);
+      --field-foreground: #133a73;
+      --field-outline: rgba(31, 88, 165, 0.18);
+      --slot-bg: #1f58a5;
+      --slot-bg-filled: #1a4b8d;
+      --slot-shadow: 0 14px 28px rgba(31, 88, 165, 0.26);
+      --slot-shadow-hover: 0 20px 36px rgba(31, 88, 165, 0.34);
+      --slot-text: #f4f8ff;
+      --slot-number-text: #163d73;
+      --role-slot-bg: rgba(255, 255, 255, 0.18);
+      --role-slot-starter-bg: rgba(255, 255, 255, 0.24);
+      --role-slot-sub-bg: rgba(9, 47, 98, 0.32);
+      --placeholder-bg: rgba(255, 255, 255, 0.22);
+    }
+
+    .team-card[data-team-id="neutral"] {
+      --field-bg: linear-gradient(180deg, #f0f2f5 0%, #e4e7ec 100%);
+      --field-foreground: #2b303a;
+      --field-outline: rgba(80, 86, 99, 0.2);
+      --slot-bg: #5f6673;
+      --slot-bg-filled: #505764;
+      --slot-shadow: 0 14px 28px rgba(80, 86, 99, 0.26);
+      --slot-shadow-hover: 0 20px 36px rgba(80, 86, 99, 0.32);
+      --slot-text: #f9fbff;
+      --slot-number-text: #2e333c;
+      --role-slot-bg: rgba(255, 255, 255, 0.14);
+      --role-slot-starter-bg: rgba(255, 255, 255, 0.2);
+      --role-slot-sub-bg: rgba(34, 39, 49, 0.28);
+      --placeholder-bg: rgba(255, 255, 255, 0.18);
+    }
+
     .badge {
       display: inline-flex;
       align-items: center;
@@ -332,8 +381,8 @@
       position: relative;
       border-radius: 24px;
       padding: 28px;
-      background: linear-gradient(180deg, #15733b 0%, #0f9d58 60%, #0a7b34 100%);
-      box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.1);
+      background: var(--field-bg, linear-gradient(180deg, #dff5e6 0%, #c9ebd6 100%));
+      box-shadow: inset 0 0 0 1px var(--field-outline, rgba(255, 255, 255, 0.25));
       display: grid;
       grid-template-columns: repeat(8, minmax(0, 1fr));
       grid-auto-rows: minmax(92px, 1fr);
@@ -341,31 +390,17 @@
       justify-items: center;
       width: 100%;
       margin: 0 auto;
-      color: #fff;
+      color: var(--field-foreground, #134f2d);
     }
 
     .composition-field::before,
     .composition-field::after {
-      content: "";
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      width: calc(100% - 48px);
-      border-top: 1px dashed rgba(255, 255, 255, 0.35);
-    }
-
-    .composition-field::before {
-      top: 20%;
-    }
-
-    .composition-field::after {
-      bottom: 20%;
+      display: none;
     }
 
     .position-slot {
       position: relative;
       border-radius: 18px;
-      border: 1.5px solid transparent;
       padding: 12px 14px 16px;
       display: flex;
       flex-direction: column;
@@ -374,37 +409,21 @@
       text-align: center;
       gap: 6px;
       transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-      background:
-        linear-gradient(162deg, rgba(13, 95, 52, 0.82), rgba(8, 67, 34, 0.6)) padding-box,
-        linear-gradient(140deg, rgba(0, 168, 232, 0.48), rgba(10, 54, 146, 0.7), rgba(12, 109, 59, 0.65)) border-box;
-      box-shadow: 0 22px 38px rgba(0, 0, 0, 0.32);
-      backdrop-filter: blur(3px);
-      isolation: isolate;
+      background: var(--slot-bg, #1f7a4a);
+      box-shadow: var(--slot-shadow, 0 14px 28px rgba(31, 122, 74, 0.28));
+      color: var(--slot-text, #f5fffb);
       width: min(100%, var(--slot-max-width));
       max-width: var(--slot-max-width);
       justify-self: center;
     }
 
-    .position-slot::after {
-      content: "";
-      position: absolute;
-      inset: 16px 20px -26px;
-      background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.35), transparent 65%);
-      border-radius: 999px;
-      z-index: -1;
-      opacity: 0.65;
-      pointer-events: none;
-    }
-
     .position-slot:hover {
       transform: translateY(-3px);
-      box-shadow: 0 28px 48px rgba(0, 0, 0, 0.42);
+      box-shadow: var(--slot-shadow-hover, 0 20px 36px rgba(31, 122, 74, 0.36));
     }
 
     .position-slot.filled {
-      background:
-        linear-gradient(165deg, rgba(15, 118, 64, 0.9), rgba(10, 78, 41, 0.68)) padding-box,
-        linear-gradient(140deg, rgba(0, 168, 232, 0.55), rgba(10, 54, 146, 0.78), rgba(15, 128, 71, 0.72)) border-box;
+      background: var(--slot-bg-filled, var(--slot-bg, #1f7a4a));
     }
 
     .position-number {
@@ -414,19 +433,19 @@
       width: 36px;
       height: 36px;
       border-radius: 50%;
-      background: rgba(255, 255, 255, 0.85);
-      color: var(--accent);
+      background: var(--slot-number-bg, rgba(255, 255, 255, 0.85));
+      color: var(--slot-number-text, var(--slot-bg, #1f7a4a));
       font-weight: 700;
       font-size: 1.1rem;
     }
 
     .position-slot .player {
       width: 100%;
-      background: #fff;
-      color: var(--accent);
+      background: transparent;
+      color: inherit;
       border: none;
       box-shadow: none;
-      --player-cover-color: #fff;
+      --player-cover-color: transparent;
     }
 
     .position-player {
@@ -440,26 +459,19 @@
       position: relative;
       width: 100%;
       border-radius: 12px;
-      border: 1px solid rgba(255, 255, 255, 0.45);
-      background: rgba(255, 255, 255, 0.12);
-      padding: 6px 12px 6px 20px;
+      border: none;
+      background: var(--role-slot-bg, rgba(255, 255, 255, 0.16));
+      padding: 6px 16px;
       display: flex;
       align-items: center;
       justify-content: center;
       min-height: 44px;
-      transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+      transition: background 0.2s ease, box-shadow 0.2s ease;
       cursor: grab;
     }
 
     .role-slot::before {
-      content: "";
-      position: absolute;
-      left: 10px;
-      top: 6px;
-      bottom: 6px;
-      width: 4px;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.6);
+      display: none;
     }
 
     .role-slot.filled {
@@ -467,22 +479,12 @@
     }
 
     .role-slot.starter {
-      background: rgba(255, 255, 255, 0.24);
-      border-color: rgba(255, 255, 255, 0.85);
-      box-shadow: 0 6px 14px rgba(9, 40, 94, 0.28);
-    }
-
-    .role-slot.starter::before {
-      background: var(--accent-alt);
+      background: var(--role-slot-starter-bg, rgba(255, 255, 255, 0.22));
+      box-shadow: var(--role-slot-starter-shadow, 0 6px 16px rgba(0, 0, 0, 0.16));
     }
 
     .role-slot.substitute {
-      background: rgba(12, 75, 38, 0.25);
-      border-style: dashed;
-    }
-
-    .role-slot.substitute::before {
-      background: rgba(255, 255, 255, 0.45);
+      background: var(--role-slot-sub-bg, rgba(0, 0, 0, 0.14));
     }
 
     .role-player {
@@ -497,11 +499,11 @@
       align-items: center;
       justify-content: center;
       font-size: 0.82rem;
-      color: rgba(255, 255, 255, 0.78);
+      color: var(--slot-text, #f5fffb);
       padding: 6px 8px;
       border-radius: 10px;
-      border: 1px dashed rgba(255, 255, 255, 0.45);
-      background: rgba(12, 75, 38, 0.3);
+      border: none;
+      background: var(--placeholder-bg, rgba(255, 255, 255, 0.18));
       pointer-events: none;
     }
 


### PR DESCRIPTION
## Summary
- ajoute des variables de thème par équipe afin de différencier les terrains et cartes des blocs bleu, vert et neutre
- modernise l'apparence du terrain et des cartes en supprimant les bordures et en simplifiant les contrastes
- épure le terrain en retirant les lignes pointillées et en harmonisant les zones de titulaires et remplaçants

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb113ede7c8333b240b3421640b37a