### PR TITLE
Improve team display and add font size control

### DIFF
--- a/composeur-rugby.html
+++ b/composeur-rugby.html
@@ -59,10 +59,11 @@
       align-items: center;
       gap: 16px;
       justify-content: space-between;
+      font-size: calc(1rem / var(--page-font-scale));
     }
 
     header h1 {
-      font-size: clamp(1.75rem, 2vw, 2.25rem);
+      font-size: clamp(1.75em, 2vw, 2.25em);
     }
 
     .font-controls {
@@ -81,7 +82,7 @@
       background: none;
       color: var(--accent);
       font-weight: 600;
-      font-size: 1.05rem;
+      font-size: 1.05em;
       padding: 4px 6px;
       line-height: 1;
       min-width: 32px;


### PR DESCRIPTION
## Summary
- differentiate titular and substitute players with role-specific icons and typography tweaks
- rename the interface title to "Gestion des groupes d’entraînement"
- add adjustable font size controls for the team cards and persist the preference

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb1b97f8748333a61ba22f3ba60fd6