### PR TITLE
Réduit les espacements des zones principales

### DIFF
--- a/composeur-rugby.html
+++ b/composeur-rugby.html
@@ -47,7 +47,7 @@
 
     .page {
       min-height: 100vh;
-      padding: 24px clamp(12px, 4vw, 48px);
+      padding: 5px;
       display: flex;
       flex-direction: column;
       gap: 24px;
@@ -143,14 +143,14 @@
       gap: 16px;
       background: var(--card);
       border-radius: 20px;
-      padding: 20px;
+      padding: 3px;
       box-shadow: 0 12px 30px rgba(15, 35, 95, 0.08);
       border: 1px solid rgba(12, 41, 92, 0.06);
       align-self: stretch;
       min-height: 100%;
       border-right: 1px solid var(--border);
       position: sticky;
-      top: 24px;
+      top: 5px;
       max-height: calc(100vh - 48px);
       overflow-y: auto;
     }
@@ -185,7 +185,7 @@
       min-height: 140px;
       border-radius: 16px;
       border: 1px solid var(--border);
-      padding: 16px;
+      padding: 3px;
       resize: vertical;
       font: inherit;
     }
@@ -202,7 +202,7 @@
       display: flex;
       gap: 8px;
       min-height: 120px;
-      padding: 12px;
+      padding: 3px;
       border-radius: 16px;
       border: 1px dashed var(--border);
       background: #f9fbff;
@@ -335,7 +335,7 @@
       gap: 20px;
       background: var(--card);
       border-radius: 20px;
-      padding: 24px;
+      padding: 3px;
       box-shadow: 0 12px 30px rgba(15, 35, 95, 0.08);
       border: 1px solid rgba(12, 41, 92, 0.06);
     }
@@ -431,7 +431,7 @@
     .composition-field {
       position: relative;
       border-radius: 24px;
-      padding: 28px;
+      padding: 3px;
       background: var(--field-bg, linear-gradient(180deg, #dff5e6 0%, #c9ebd6 100%));
       box-shadow: inset 0 0 0 1px var(--field-outline, rgba(255, 255, 255, 0.25));
       display: grid;
@@ -664,7 +664,7 @@
 
       .composition-field {
         grid-auto-rows: minmax(72px, 1fr);
-        padding: 22px;
+        padding: 3px;
       }
     }
 
@@ -706,7 +706,7 @@
         align-self: flex-end;
       }
       .composition-field {
-        padding: 18px;
+        padding: 3px;
       }
     }
 


### PR DESCRIPTION
## Summary
- réduit le padding général de la page à 5px pour rapprocher le contenu des bords
- compresse les espacements internes de la sidebar, des listes de joueurs et des cartes d’équipe à 3px
- ajuste la zone sticky de la barre latérale pour rester cohérente avec les nouveaux espacements

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68cbeca98c7c8333929d1c30d0e2d069