### PR TITLE
Réduire les marges horizontales

### DIFF
--- a/composeur-rugby.html
+++ b/composeur-rugby.html
@@ -47,7 +47,7 @@
 
     .page {
       min-height: 100vh;
-      padding: 24px clamp(12px, 4vw, 48px);
+      padding: 24px clamp(8px, 2vw, 10px);
       display: flex;
       flex-direction: column;
       gap: 24px;
@@ -133,7 +133,8 @@
     .layout {
       display: grid;
       grid-template-columns: clamp(300px, 24vw, 400px) 1fr;
-      gap: 24px;
+      column-gap: 5px;
+      row-gap: 24px;
       align-items: start;
     }
 

--- a/composeur-rugby.html
+++ b/composeur-rugby.html
@@ -133,7 +133,7 @@
     .layout {
       display: grid;
       grid-template-columns: clamp(300px, 24vw, 400px) 1fr;
-      column-gap: 5px;
+      column-gap: 10px;
       row-gap: 24px;
       align-items: start;
     }
@@ -327,7 +327,7 @@
     .teams {
       display: flex;
       flex-direction: column;
-      gap: 24px;
+      gap: 10px;
     }
 
     .composition-card {


### PR DESCRIPTION
## Summary
- réduire les marges latérales globales de la page pour maximiser l’espace utile
- réduire l’écart entre la colonne latérale et le contenu principal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbf0f06604833385a52c0af3919e0f